### PR TITLE
Use smuggler prefix as a backend route

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "eslintConfig": {
     "extends": "react-app"
   },
-  "proxy": "http://localhost:8080",
+  "proxy": "http://0.0.0.0:8080",
   "browserslist": {
     "production": [
       ">0.2%",

--- a/src/smugler/api.js
+++ b/src/smugler/api.js
@@ -21,10 +21,10 @@ const kHeaderNodeMeta = 'x-node-meta'
 
 const kHeaderContentTypeUtf8 = 'text/plain; charset=utf-8'
 
-function _getSmuglerApiHost() {
+function _getSmuglerApibaseURL() {
   switch (process.env.NODE_ENV) {
     case 'production':
-      return 'https://api.thread-knowledge.dev'
+      return '/smuggler'
     case 'development':
       return null
     case 'test':
@@ -35,7 +35,7 @@ function _getSmuglerApiHost() {
 }
 
 const _client = axios.create({
-  baseURL: _getSmuglerApiHost(),
+  baseURL: _getSmuglerApibaseURL(),
   timeout: 1000,
 })
 


### PR DESCRIPTION
Last step of mazed migration to digital ocean apps [see task 2 in smuggler repo](https://github.com/Thread-knowledge/smugler/issues/2).