### PR TITLE
stop paragraph nodes from collapsing whitespace

### DIFF
--- a/src/doc/editor/components/components.css
+++ b/src/doc/editor/components/components.css
@@ -24,17 +24,17 @@
 }
 
 .doc_block_paragraph {
-  white-space: normal;
+  white-space: pre-wrap;
   margin-bottom: 14px;
   margin-top: 0;
 }
 
 div.public-DraftEditor-content {
-  white-space: normal;
+  white-space: pre-wrap;
 }
 
 div.public-DraftStyleDefault-block {
-  white-space: normal;
+  white-space: pre-wrap;
 }
 
 .doc_block_unstyled {


### PR DESCRIPTION
Without this fix all paragraph nodes have a very annoying behaviour around whitespace characters. Most commonly I encounter this when I press spacebar at the end of the line to start a new word - nothing happens, no whitespace symbols are added. But it also manifests in a lot of other subtle usecases, like trying to add two spaces in the middle of a sentence etc. Header blocks do not have this behavior.

Turns out HTML has a set of [whitespace-collapsing rules](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Whitespace) which were enabled in css for `paragraph` nodes specifically. The fun part is that every time a whitespace symbol gets inserted, it'll actually *be* in the text, just *invisible*, and with this change all of them start to render, suddenly making all the notes weird and full of spaces :P