### PR TITLE
Remove '∾' character from between "open" and "see more"

### DIFF
--- a/src/card/ShrinkCard.js
+++ b/src/card/ShrinkCard.js
@@ -56,7 +56,7 @@ const SeeMoreButton = React.forwardRef(
         onClick={onClick}
         disabled={disabled}
       >
-        {on ? 'See less' : 'See more'}
+        {on ? '...see less' : 'See more...'}
       </div>
     )
   }
@@ -72,9 +72,8 @@ export const ShrinkCard = ({ children, nid }) => {
         <div className={styles.fade} />
       </div>
       <SeeMoreButton onClick={toggleMoreLess} on={opened} />
-      {'∾'}
       <Link to={makeRefTo.node(nid)} className={styles.a_see_more}>
-        open
+        Open
       </Link>
     </>
   )

--- a/src/card/ShrinkCard.module.css
+++ b/src/card/ShrinkCard.module.css
@@ -80,8 +80,9 @@
 }
 
 .a_see_more {
-  font-weight: bold;
-  color: black;
+  font-size: 1rem;
+  font-weight: 560;
+  color: rgba(0, 0, 0, 0.6);
 
   margin: 0;
 
@@ -91,6 +92,8 @@
   margin-right: 4px;
 
   display: inline;
+
+  text-decoration: none;
 }
 
 .a_see_more:visited {


### PR DESCRIPTION
- Remove '∾' character from between "open" and "see more" - it's too bloody distracting.
- Increased font size a bit to make it easier to click on them
- Removed text decoration (underling) from there. (Looks like it appeared there after bootstrap upgrade)

### Before
![2021 08 24 Tuesday 10:03:16-selected](https://user-images.githubusercontent.com/2223470/130589712-3b0a44b8-6b04-4214-bb41-360de7ad53f6.png)

### After
![2021 08 24 Tuesday 10:03:26-selected](https://user-images.githubusercontent.com/2223470/130589734-b04c9fa7-dcba-4f54-b561-ad5b2e30e3e6.png)
