### PR TITLE
Remove header text decoration, reduce text weight to match plain text

### DIFF
--- a/src/doc/editor/components/Header.module.css
+++ b/src/doc/editor/components/Header.module.css
@@ -1,13 +1,14 @@
 .link {
   color: inherit;
+  text-decoration: none;
 }
 
 .link:hover {
   color: inherit;
   text-decoration: none;
-  text-decoration-line: underline;
-  -webkit-text-decoration-line: underline; /* Safari */
 }
 
 .link:visited {
+  color: inherit;
+  text-decoration: none;
 }

--- a/src/doc/editor/components/components.css
+++ b/src/doc/editor/components/components.css
@@ -43,7 +43,7 @@ div.public-DraftStyleDefault-block {
 
 .doc_block_header_1 {
   font-size: 1.6em;
-  font-weight: bold;
+  font-weight: 500;
   display: block;
 
   /* color: #1a4301; */
@@ -53,9 +53,12 @@ div.public-DraftStyleDefault-block {
   margin-bottom: 0.68em;
 }
 
+.doc_block_header_1:hover {
+}
+
 .doc_block_header_2 {
   font-size: 1.4em;
-  font-weight: bold;
+  font-weight: 500;
   /* color: #245501; */
   color: #006400;
   display: block;
@@ -66,7 +69,7 @@ div.public-DraftStyleDefault-block {
 
 .doc_block_header_3 {
   font-size: 1.2em;
-  font-weight: bold;
+  font-weight: 500;
   /* color: #538d22; */
   color: #007200;
   display: block;
@@ -77,7 +80,7 @@ div.public-DraftStyleDefault-block {
 
 .doc_block_header_4 {
   font-size: 1.1em;
-  font-weight: bold;
+  font-weight: 500;
   /* color: #73a942; */
   color: #008000;
   display: block;
@@ -88,7 +91,7 @@ div.public-DraftStyleDefault-block {
 
 .doc_block_header_5 {
   font-size: 1.1em;
-  font-weight: bold;
+  font-weight: 500;
   /* color: #aad576; */
   color: #38b000;
   display: block;
@@ -99,7 +102,7 @@ div.public-DraftStyleDefault-block {
 
 .doc_block_header_6 {
   font-size: 1.1em;
-  font-weight: bold;
+  font-weight: 500;
   /* color: #aad576; */
   color: #70e000;
   display: block;


### PR DESCRIPTION
Remove header text decoration and reduce text weight to match better plain text style.

### Before

![2021 08 24 Tuesday 10 24 33](https://user-images.githubusercontent.com/2223470/130593620-6de92ef0-f49e-4480-b8f6-14ac2d7fb38a.png)

### After

![2021 08 24 Tuesday 10 24 44](https://user-images.githubusercontent.com/2223470/130593636-b662f903-84eb-4b2e-b2f3-a99dacf71bb9.png)
