### PR TITLE
Swap in and out buttons on image zoom panel

### DIFF
--- a/src/doc/image/ImageNode.tsx
+++ b/src/doc/image/ImageNode.tsx
@@ -68,11 +68,11 @@ export const ImageNode = ({ className, nid, data }) => {
         <Modal.Header closeButton>
           <Modal.Title className={styles.zoom_image_title}>
             <ButtonGroup className={styles.zoom_button_group}>
-              <ImgButton onClick={handleZoomIn}>
+              <ImgButton onClick={handleZoomOut}>
                 <img
-                  src={ZoomInImg}
+                  src={ZoomOutImg}
                   className={styles.zoom_button_image}
-                  alt="Zoom in image"
+                  alt="Zoom out image"
                 />
               </ImgButton>
               <ImgButton onClick={handleZoomReset}>
@@ -82,11 +82,11 @@ export const ImageNode = ({ className, nid, data }) => {
                   alt="Reset image zoom"
                 />
               </ImgButton>
-              <ImgButton onClick={handleZoomOut}>
+              <ImgButton onClick={handleZoomIn}>
                 <img
-                  src={ZoomOutImg}
+                  src={ZoomInImg}
                   className={styles.zoom_button_image}
-                  alt="Zoom out image"
+                  alt="Zoom in image"
                 />
               </ImgButton>
             </ButtonGroup>


### PR DESCRIPTION
Place [zoom-out] to the left and [zoom-in] to the right.

Normally they are positioned in this order, let stick to it according to the principle of least astonishment