### PR TITLE
Upload to connect button on triptych footbar

### DIFF
--- a/src/card/FullCardFootbar.js
+++ b/src/card/FullCardFootbar.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types'
 
 import { smugler } from '../smugler/api'
 import { SearchGrid } from '../grid/SearchGrid'
+import { UploadNodeButton } from '../upload/UploadNodeButton'
 
 import styles from './FullCardFootbar.module.css'
 
@@ -15,6 +16,7 @@ import CopyImg from './../img/copy.png'
 import SearchImg from './../img/search.png'
 import ArchiveImg from './../img/archive.png'
 import DeleteImg from './../img/delete.png'
+import UploadImg from '../img/upload-strip.svg'
 
 import NextNewLeftImg from './../img/next-link-left-00001.png'
 import NextNewRightImg from './../img/next-link-right-00001.png'
@@ -423,17 +425,18 @@ class PrivateFullCardFootbarImpl extends React.Component {
                 />
                 Copy
               </FootbarDropdownItem>
-              <FootbarDropdownItem
+              <UploadNodeButton
                 className={styles.dropdown_menu_item}
-                onClick={this.handleNextLeftBlankCopy}
+                as={FootbarDropdownItem}
+                to_nid={this.props.nid}
               >
                 <img
-                  src={NextCopyLeftImg}
+                  src={UploadImg}
                   className={styles.dropdown_menu_inline_img}
-                  alt="Blank copy and link"
+                  alt="Upload from file"
                 />
-                Blank copy
-              </FootbarDropdownItem>
+                Upload
+              </UploadNodeButton>
               <FootbarDropdownItem
                 className={styles.dropdown_menu_item}
                 onClick={this.handleNextLeftSearch}
@@ -545,17 +548,18 @@ class PrivateFullCardFootbarImpl extends React.Component {
                 />
                 Copy
               </FootbarDropdownItem>
-              <FootbarDropdownItem
+              <UploadNodeButton
                 className={styles.dropdown_menu_item}
-                onClick={this.handleNextRightBlankCopy}
+                as={FootbarDropdownItem}
+                from_nid={this.props.nid}
               >
                 <img
-                  src={NextCopyRightImg}
+                  src={UploadImg}
                   className={styles.dropdown_menu_inline_img}
-                  alt="Blank copy and link"
+                  alt="Upload from file"
                 />
-                Blank copy
-              </FootbarDropdownItem>
+                Upload
+              </UploadNodeButton>
               <FootbarDropdownItem
                 className={styles.dropdown_menu_item}
                 onClick={this.handleNextRightSearch}

--- a/src/upload/UploadNodeButton.tsx
+++ b/src/upload/UploadNodeButton.tsx
@@ -9,7 +9,7 @@ import { Emoji } from '../Emoji'
 import { goto } from '../lib/route'
 import { debug } from '../util/log'
 import { jcss } from '../util/jcss'
-import { smugler } from '../smugler/api'
+import { smugler, CancelToken } from '../smugler/api'
 import { Optional } from '../util/types'
 
 import UploadImg from '../img/upload-strip.svg'
@@ -17,7 +17,7 @@ import UploadImg from '../img/upload-strip.svg'
 import styles from './UploadNodeButton.module.css'
 
 export const UploadNodeButton = React.forwardRef(
-  ({ children, className, disabled, from_nid, to_nid, ...kwargs }, ref) => {
+  ({ children, className, from_nid, to_nid, ...kwargs }, ref) => {
     className = jcss(styles.btn, className)
     children = children || (
       <img
@@ -32,7 +32,6 @@ export const UploadNodeButton = React.forwardRef(
         <Button
           className={className}
           ref={ref}
-          disabled={disabled}
           onClick={(e) => {
             e.preventDefault()
             const { current } = fileInputRef
@@ -139,6 +138,8 @@ class FileUploadStatus extends React.Component<
   FileUploadStatusProps,
   FileUploadStatusState
 > {
+  cancelToken: CancelToken
+
   constructor(props: FileUploadStatusProps) {
     super(props)
     this.state = {


### PR DESCRIPTION
Replace [blank copy and connect] with [upload to connect] button on triptych footbar to be able to upload local files as nodes directly connected to a certain node.

User workflow looks like this:

1.

![2021 08 31 Tuesday 09:50:08-selected](https://user-images.githubusercontent.com/2223470/131473178-7a8ea254-baee-44da-afde-58d7bbe426c3.png)

2.

![2021 08 31 Tuesday 09:50:19-selected](https://user-images.githubusercontent.com/2223470/131473272-13f15612-d99e-4513-ba07-914242b19cc9.png)

3.

![2021 08 31 Tuesday 09:50:32-selected](https://user-images.githubusercontent.com/2223470/131473292-d199cd41-0dbe-4d3d-b0b6-91acdb8c2426.png)

4.

![2021 08 31 Tuesday 09:50:41-selected](https://user-images.githubusercontent.com/2223470/131473334-375643b9-dbac-419b-a86d-f50669663236.png)

5.

![2021 08 31 Tuesday 09:50:49-selected](https://user-images.githubusercontent.com/2223470/131473344-7ea797d0-bab7-4042-8a77-919df4730b4e.png)

⚠ It's based on 2 PRs, don't merge it before them:
1. #44
2. [Smuggler PR26](https://github.com/Thread-knowledge/smugler/pull/26)


