### PR TITLE
Turn on default search for Jinn

### DIFF
--- a/src/card/FullCardFootbar.js
+++ b/src/card/FullCardFootbar.js
@@ -115,7 +115,7 @@ class SearchAndConnectJinnModal extends React.Component {
         />
         <SearchGrid
           q={q}
-          defaultSearch={false}
+          defaultSearch
           onCardClick={this.onNodeCardClick}
           portable
         >

--- a/src/doc/editor/plugins/jinn.tsx
+++ b/src/doc/editor/plugins/jinn.tsx
@@ -139,7 +139,7 @@ class JinnModal extends React.Component<JinnModalProps, JinnModalState> {
         />
         <SearchGrid
           q={q}
-          defaultSearch={false}
+          defaultSearch
           onCardClick={this.onNodeCardClick}
           portable
         >

--- a/src/grid/SearchGrid.js
+++ b/src/grid/SearchGrid.js
@@ -282,7 +282,7 @@ class SearchGridImpl extends React.Component {
     return innerHeight + scrollTop >= offsetHeight
   }
 
-  handleScroll = (e) => {
+  handleScroll = () => {
     if (!this.state.fetching && this.isScrolledToBottom()) {
       this.secureSearchIteration()
     }
@@ -351,7 +351,6 @@ class SearchGridImpl extends React.Component {
   }
 }
 
-// SearchGridImpl.contextType = MzdGlobalContext;
 const SearchGridRouter = withRouter(SearchGridImpl)
 
 export function SearchGrid({ ...rest }) {


### PR DESCRIPTION
Turn on default search for Jinn smart search and search-to-connect dialogue.

See screenshot below:

![2021 09 01 Wednesday 09:38:15-selected](https://user-images.githubusercontent.com/2223470/131640110-475cc536-1156-4b33-833c-6e24ca5f7a84.png)
