### PR TITLE
[bug] Fix data race in copy-as-markdown button

### DIFF
--- a/src/card/FullCard.tsx
+++ b/src/card/FullCard.tsx
@@ -3,8 +3,9 @@ import React from 'react'
 import { FullCardFootbar } from './FullCardFootbar'
 import { WideCard } from './WideCard'
 
-import { DocEditor } from '../doc/DocEditor.tsx'
+import { DocEditor } from '../doc/DocEditor'
 import { ImageNode } from '../doc/image/ImageNode'
+import { SlateText } from '../doc/types'
 
 import { Loader } from '../lib/loader'
 
@@ -19,7 +20,7 @@ export function FullCard({ node, addRef, stickyEdges, saveNode }) {
     editor = <Loader />
   } else {
     const { data, nid } = node
-    const saveText = (text) => {
+    const saveText = (text: SlateText) => {
       node.data = data.updateText(text)
       saveNode(node)
     }

--- a/src/card/FullCardFootbar.js
+++ b/src/card/FullCardFootbar.js
@@ -749,9 +749,9 @@ export function FullCardFootbar({ children, node, ...rest }) {
   const { account } = ctx
   if (node && node.meta) {
     const { nid, meta } = node
-    const data = node.getData()
     if (node.isOwnedBy(account)) {
       const getMarkdown = () => {
+        const data = node.getData()
         return docAsMarkdown(nid, data)
       }
       return (


### PR DESCRIPTION
Fix data race in copy-as-markdown button. Caused by capturing raw node data into lambda function instead of original node, so latests changes to the document are not appear in the result markdown.