### PR TITLE
[fix] Reposition navbar account dropdown

### DIFF
--- a/src/navbar/GlobalNavBar.js
+++ b/src/navbar/GlobalNavBar.js
@@ -138,6 +138,7 @@ class PrivateNavButtonsImpl extends React.Component {
           className={jcss(styles.account_dropdown)}
           as={ButtonGroup}
           navbar
+          drop="start"
         >
           <Dropdown.Toggle
             variant="light"
@@ -216,7 +217,7 @@ function GlobalNavBar() {
   }
   return (
     <>
-      <Navbar className={styles.navbar}>
+      <Navbar fixed="top" className={styles.navbar}>
         <Navbar.Brand as={Link} to="/" className={jcss(styles.brand)}>
           <span role="img" aria-label="next">
             &#x1F9F5;

--- a/src/navbar/GlobalNavBar.module.css
+++ b/src/navbar/GlobalNavBar.module.css
@@ -46,10 +46,6 @@
   background-color: white;
 
   height: 2.8rem;
-  position: fixed;
-  top: 0;
-  width: 100%;
-  z-index: 2048;
 
   padding-left: 0.8rem;
   padding-right: 0.8rem;
@@ -90,7 +86,8 @@
 .user_pic_image {
   width: 1.4rem;
   height: 1.4rem;
-  margin: auto;
+  margin-top: auto;
+  margin-bottom: auto;
   margin-right: 0.4rem;
   margin-left: 0.4rem;
 }
@@ -105,10 +102,10 @@
   border-width: 0px;
   border-radius: 56px;
 
-  padding: 0;
-  padding: 0.25rem;
-  padding-top: 0.55rem;
-  padding-right: 0.55rem;
+  padding-top: 8px;
+  padding-right: 4px;
+  padding-left: 4px;
+  padding-bottom: 4px;
 
   margin-right: 0.2rem;
 }
@@ -118,5 +115,8 @@
   background-color: #d0d1d2;
 }
 .account_dropdown_toggle:after {
-  display: none;
+  display: none !important;
+}
+.account_dropdown_toggle:before {
+  display: none !important;
 }


### PR DESCRIPTION
Reposition navbar account dropdown to avoid hiding part of it outside of view frame (see before screenshot)

## Before

![2021 09 05 Sunday 20:21:03-selected](https://user-images.githubusercontent.com/2223470/132138902-aadfc1a1-1942-4fc3-ae95-b0dc6b02e645.png)


## After
![2021 09 05 Sunday 20:18:24-selected](https://user-images.githubusercontent.com/2223470/132138855-ad0ed5f5-df9f-4684-ac94-0fddf7e0e7b9.png)
