### PR TITLE
make format toolbar scrollable for narrow screens

### DIFF
--- a/src/doc/FormatToolbar.module.css
+++ b/src/doc/FormatToolbar.module.css
@@ -23,6 +23,6 @@
   display: flex;
   /* To make usable on narrow screens */
   /* https://www.w3schools.com/howto/howto_css_menu_horizontal_scroll.asp */
-  overflow: auto;
+  overflow-x: auto;
   white-space: nowrap;
 }


### PR DESCRIPTION
This is a cheap hotfix to make all toolbar buttons accessible on mobile devices.

See in action:

https://user-images.githubusercontent.com/3685502/134782957-c080dbd6-3d06-420d-9aa2-ecfabb691562.mp4


