### PR TITLE
Add `indext_text` and `extattrs` fields to `smuggler.node.create`

### DIFF
--- a/smuggler-api/src/api.ts
+++ b/smuggler-api/src/api.ts
@@ -1,13 +1,15 @@
 import {
+  AccountInfo,
+  Ack,
   EdgeAttributes,
   EdgeStar,
   NewNodeResponse,
   NodeExtattrs,
+  NewNodeRequestBody,
+  NodeIndexText,
   NodeTextData,
   TEdge,
   TNode,
-  Ack,
-  AccountInfo,
 } from './types'
 
 import { Mime } from './util/mime'
@@ -28,14 +30,18 @@ export function makeUrl(path?: string, query?: Record<string, any>): string {
 }
 
 async function createNode({
-  doc,
-  from_nid /* Optional<string> */,
-  to_nid /* Optional<string> */,
+  text,
+  from_nid,
+  to_nid,
+  index_text,
+  extattrs,
   signal,
 }: {
-  doc: NodeTextData
+  text: NodeTextData
   from_nid?: string
   to_nid?: string
+  index_text?: NodeIndexText
+  extattrs?: NodeExtattrs
   signal?: AbortSignal
 }): Promise<Optional<NewNodeResponse>> {
   signal = signal || undefined
@@ -43,9 +49,14 @@ async function createNode({
     from: from_nid || undefined,
     to: to_nid || undefined,
   }
+  const body: NewNodeRequestBody = {
+    text,
+    index_text: index_text || null,
+    extattrs: extattrs || null,
+  }
   const resp = await fetch(makeUrl('node/new', query), {
     method: 'POST',
-    body: JSON.stringify({ text: doc }),
+    body: JSON.stringify(body),
     headers: { 'Content-type': Mime.JSON },
     signal,
   })

--- a/smuggler-api/src/types.ts
+++ b/smuggler-api/src/types.ts
@@ -271,3 +271,13 @@ export type AccountInfo = {
   name: string
   email: string
 }
+
+export type NodeIndexText = {
+  plaintext: Optional<string>
+}
+
+export type NewNodeRequestBody = {
+  text: Optional<NodeTextData>
+  index_text: Optional<NodeIndexText>
+  extattrs: Optional<NodeExtattrs>
+}

--- a/truthsayer/src/card/ChainActionBar.tsx
+++ b/truthsayer/src/card/ChainActionBar.tsx
@@ -50,7 +50,7 @@ async function cloneNode({
   let doc = await TDoc.fromNodeTextData(node.getText())
   doc = doc.makeACopy(node.getNid(), isBlank || false)
   return await smuggler.node.create({
-    doc: doc.toNodeTextData(),
+    text: doc.toNodeTextData(),
     abortControler,
     from_nid: from,
     to_nid: to,

--- a/truthsayer/src/navbar/GlobalNavBar.js
+++ b/truthsayer/src/navbar/GlobalNavBar.js
@@ -95,7 +95,7 @@ class PrivateNavButtonsImpl extends React.Component {
     makeDoc({})
       .then((doc) => {
         return smuggler.node.create({
-          doc: doc.toNodeTextData(),
+          text: doc.toNodeTextData(),
           signal: this.newNodeAbortController.signal,
           signal: this.newNodeAbortController.signal,
         })


### PR DESCRIPTION
Add `indext_text` and `extattrs` fields to `smuggler.node.create`. Just added fields to an interface of the TS wrapper, the functionality is already added to smuggler earlier.