### PR TITLE
Use correct domain name to open new mazed tabs

### DIFF
--- a/archaeologist/src/components/PopUpApp.tsx
+++ b/archaeologist/src/components/PopUpApp.tsx
@@ -8,6 +8,7 @@ import { MessageType } from './../message/types'
 import { ViewActiveTabStatus } from './ViewActiveTabStatus'
 import { Relative, HVCentered } from './../util/layout'
 import { Button } from './Button'
+import { mazed } from '../util/mazed'
 
 const AppContainer = styled.div`
   width: 280px;
@@ -43,9 +44,9 @@ const LogoImg = styled.img`
 
 const LoginPage = () => {
   const onClick = () => {
-    let url = new URL(process.env.REACT_APP_SMUGGLER_API_URL || '')
-    url.pathname = '/login'
-    chrome.tabs.create({ url: url.toString() })
+    chrome.tabs.create({
+      url: mazed.makeUrl({ pathname: '/login' }).toString(),
+    })
   }
   return (
     <Relative>

--- a/archaeologist/src/components/SavePageButton.tsx
+++ b/archaeologist/src/components/SavePageButton.tsx
@@ -3,11 +3,11 @@
 import * as React from 'react'
 import styled from '@emotion/styled'
 
-import { MdiBookmarkAdd, MdiLaunch } from 'elementary'
+import { MdiBookmarkAdd, MdiLaunch, Spinner } from 'elementary'
 import { Button } from './Button'
 
 import { MessageType } from './../message/types'
-import { Spinner } from 'elementary'
+import { mazed } from '../util/mazed'
 
 const Container = styled.div`
   margin: 0;
@@ -54,9 +54,9 @@ export const SavePageButton = () => {
 
   const handleGoToNode = () => {
     const { nid } = pageSavedNode as Node
-    let url = new URL(process.env.REACT_APP_SMUGGLER_API_URL || '')
-    url.pathname = `/n/${nid}`
-    chrome.tabs.create({ url: url.toString() })
+    chrome.tabs.create({
+      url: mazed.makeNodeUrl(nid).toString(),
+    })
   }
 
   let btn

--- a/archaeologist/src/util/mazed.ts
+++ b/archaeologist/src/util/mazed.ts
@@ -1,0 +1,16 @@
+import lodash from 'lodash'
+
+const makeUrl = (params: { pathname?: string }): URL => {
+  let url = new URL(process.env.REACT_APP_SMUGGLER_API_URL || '')
+  lodash.extend(url, params)
+  return url
+}
+
+const makeNodeUrl = (nid: string): URL => {
+  return makeUrl({ pathname: `/n/${nid}` })
+}
+
+export const mazed = {
+  makeUrl,
+  makeNodeUrl,
+}


### PR DESCRIPTION
Use mazed domain name from `process.env.REACT_APP_SMUGGLER_API_URL` rather than from `authCookie.url`. The latter one gets domain name from `window` if availiable, and only if there is now window var it gets value from `process.env.REACT_APP_SMUGGLER_API_URL`. The thing is, `window` global var is availiable for pop up extension window with broweser generated url - which is completely unrelated to `mazed` dev or prod.