### PR TITLE
Bump arhaeologist version up to 0.0.3 to release for chrome

### DIFF
--- a/archaeologist/public/manifest.json
+++ b/archaeologist/public/manifest.json
@@ -2,15 +2,14 @@
   "manifest_version": 3,
   "name": "Mazed",
   "author": "Thread knowledge",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Bookmark web pages to Mazed",
   "action": {
     "default_icon": {
       "16": "logo-16x16.png",
       "48": "logo-48x48.png",
       "72": "logo-72x72.png",
-      "128": "logo-128x128.png",
-      "240": "logo-240x240.png"
+      "128": "logo-128x128.png"
     },
     "default_title": "Mazed",
     "default_popup": "popup.html"


### PR DESCRIPTION
Each release in Chrome Web Store has to have a higher version.