### PR TITLE
Syncronise z-index of create-and-connect dropdown and small card footbar

### DIFF
--- a/elementary/src/editor/plugins/jinn.tsx
+++ b/elementary/src/editor/plugins/jinn.tsx
@@ -2,6 +2,8 @@
 
 import React from 'react'
 
+import styled from '@emotion/styled'
+
 import {
   Editor,
   Element as SlateElement,
@@ -34,6 +36,10 @@ type JinnModalState = {
   q: string
   cursor: number
 }
+
+const JinnInput = styled(Form.Control)`
+  margin-bottom: 8px;
+`
 
 class JinnModal extends React.Component<JinnModalProps, JinnModalState> {
   state: JinnModalState = {
@@ -116,7 +122,7 @@ class JinnModal extends React.Component<JinnModalProps, JinnModalState> {
     // extCards={this.state.cards}
     return (
       <div>
-        <Form.Control
+        <JinnInput
           aria-label="Search-to-link"
           aria-describedby="basic-addon1"
           onChange={this.handleChange}

--- a/truthsayer/src/card/Footbar.module.css
+++ b/truthsayer/src/card/Footbar.module.css
@@ -17,7 +17,7 @@
   vertical-align: baseline;
 
   color: black;
-  opacity: 0.6;
+  opacity: 0.5;
   z-index: 101;
 }
 

--- a/truthsayer/src/card/Triptych.tsx
+++ b/truthsayer/src/card/Triptych.tsx
@@ -66,7 +66,7 @@ function RefNodeCard({
           position: absolute;
           bottom: 0;
           right: 0;
-          z-index: 1000;
+          z-index: 900;
         `}
       >
         <SmallCardFootbar


### PR DESCRIPTION
Syncronise z-index of create-and-connect dropdown and small card footbar. There is a big mess in z-indexes in trutsayer today, we'd have to fix it one day. As for now this is a tiny fix to make the look right:

## Before

<img width="356" alt="Screenshot 2022-04-11 at 09 22 33" src="https://user-images.githubusercontent.com/2223470/162695782-84717f21-43d6-4b52-ba9a-42db591742e2.png">

## After
<img width="488" alt="Screenshot 2022-04-11 at 09 22 59" src="https://user-images.githubusercontent.com/2223470/162695775-ef012069-aef4-4544-a14e-6e344c148fe8.png">
