### PR TITLE
Use special extractor for YouTube pages

### DIFF
--- a/archaeologist/src/content/QuoteToolbar.tsx
+++ b/archaeologist/src/content/QuoteToolbar.tsx
@@ -30,6 +30,7 @@ const ItemCommon = css`
   cursor: pointer !important;
   font-size: 14px !important;
   ${StyleButtonWhite};
+  box-shadow: none !important;
 `
 
 const BtnItem = styled.div`

--- a/archaeologist/src/extractor/webPageContent.test.tsx
+++ b/archaeologist/src/extractor/webPageContent.test.tsx
@@ -1,5 +1,5 @@
-// Do not remove this import
-import React from 'react' // eslint-disable-line @typescript-eslint/no-unused-vars
+// @ts-ignore: Do not remove this import, it's somewhat needed for jsdom
+import type React from 'react' // eslint-disable-line @typescript-eslint/no-unused-vars
 
 /**
  * @jest-environment jsdom
@@ -16,6 +16,7 @@ import {
   _exctractPageTitle,
   _exctractYouTubeVideoObjectSchema,
   _extractPageAttributes,
+  _extractPageThumbnailUrls,
   _stripWhitespaceInText,
   exctractPageContent,
 } from './webPageContent'
@@ -278,5 +279,39 @@ test('YouTube special extractor has a priority', () => {
   expect(publisher).toStrictEqual(['YouTube'])
   expect(thumbnailUrls).toStrictEqual([
     'https://i.ytimg.com/vi/WAIcDx8B1_0/hqdefault.jpg',
+  ])
+})
+
+test('_extractPageThumbnailUrls', () => {
+  const dom = new JSDOM(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<link rel="icon" type="image/x-icon" href="/favicon.ico">
+<link rel="shortcut icon" href="https://www.youtube.com/s/e69b/img/favicon.ico" type="image/x-icon">
+<meta property="og:image" content="https://og.ytimg.com/vi/p3bdV/og.jpg">
+<meta name="twitter:image" content="https://twitter.ytimg.com/vi/kKGRQ/twitter.jpg">
+<meta name="vk:image" content="https://vk.ytimg.com/vi/ddd/vk.jpg">
+<link rel="apple-touch-icon" href="/apple-touch-icon-1024.png">
+<link rel="image_src" href="https://abc.abc/images/007/qOoFNK6Z7.png">
+<link itemprop="thumbnailUrl" href="https://thumb.ytimg.com/vi/RQ/df.jpg">
+</head>
+<body >
+</body>
+</html>
+`)
+  const refs = _extractPageThumbnailUrls(
+    dom.window.document,
+    'https://base.ytimg.com'
+  )
+  // Order of elements does mater here, the best options come first.
+  expect(refs).toStrictEqual([
+    'https://og.ytimg.com/vi/p3bdV/og.jpg',
+    'https://twitter.ytimg.com/vi/kKGRQ/twitter.jpg',
+    'https://vk.ytimg.com/vi/ddd/vk.jpg',
+    'https://abc.abc/images/007/qOoFNK6Z7.png',
+    'https://thumb.ytimg.com/vi/RQ/df.jpg',
+    'https://base.ytimg.com/apple-touch-icon-1024.png',
+    'https://www.youtube.com/s/e69b/img/favicon.ico',
+    'https://base.ytimg.com/favicon.ico',
   ])
 })

--- a/archaeologist/src/extractor/webPageContent.ts
+++ b/archaeologist/src/extractor/webPageContent.ts
@@ -433,15 +433,18 @@ export function _extractPageThumbnailUrls(
   // - VK preview image.
   // - Favicon, locations according to https://en.wikipedia.org/wiki/Favicon,
   //    with edge case for Apple specific web page icon.
+  // - Thumbnail image
+  //
+  // Order of elements does mater here, the best options come first.
   for (const [selector, attribute] of [
     ['meta[property="og:image"]', 'content'],
     ['meta[name="twitter:image"]', 'content'],
     ['meta[name="vk:image"]', 'content'],
+    ['link[rel="image_src"]', 'href'],
+    ['link[itemprop="thumbnailUrl"]', 'href'],
     ['link[rel="apple-touch-icon"]', 'href'],
     ['link[rel="shortcut icon"]', 'href'],
     ['link[rel="icon"]', 'href'],
-    ['link[rel="image_src"]', 'href'],
-    ['link[itemprop="thumbnailUrl"]', 'href'],
   ]) {
     for (const element of document_.querySelectorAll(selector)) {
       const ref = element.getAttribute(attribute)?.trim()


### PR DESCRIPTION
Use special extractor for YouTube pages, because they messed up with head tags in a way that if you open some video and click a few times on other videos and only then decide to save some of them the head tags would still have the information about the first opened one.

For example user opened a "news" video with some horrible content and opened a few others after clicking on links in YouTube itself and then decide to save one of them, let's say some "kitten" video. Archaeologist would save kitten URL with metadata of that horrible "news" video including preview image, title and description :( Not nice

To fix that I added a special extractor for YouTube, which rely on published [`VideoObject` schematised json](https://schema.org/VideoObject) for each video. So we can easily find it in DOM and parse.