### PR TITLE
reuse MS auth results between tabs/sessions

### DIFF
--- a/truthsayer/src/3rdparty-integration/MicrosoftAuthentication.ts
+++ b/truthsayer/src/3rdparty-integration/MicrosoftAuthentication.ts
@@ -31,6 +31,22 @@ export function makeInstance(): PublicClientApplication {
       redirectUri: '/',
       postLogoutRedirectUri: '/',
     },
+    cache: {
+      // When a user authenticates with Microsoft Graph via MSAL,
+      // MSAL automatically caches the results and reuses them later if possible
+      // to reduce the amount of login prompts user has to see.
+      // 'cacheLocation' configures how access tokens are stored in a browser.
+      // The default value is 'sessionStorage' which doesn't allow the login
+      // session to be shared between tabs.
+      //
+      // If Mazed is used in a browser (as opposed to a dedicated app),
+      // 'localStorage' is more convenient as it allows to reuse cached tokens
+      // across multiple tabs (note that closing a tab & then opening it again
+      // also falls into this category).
+      // See https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-js-sso#sso-between-browser-tabs
+      // for more details.
+      cacheLocation: 'localStorage',
+    },
   }
 
   // "Public" in MSAL terminology means "not trusted to know a secret key".


### PR DESCRIPTION
Before this change a user had to re-authenticate with Microsoft Graph every time they open Mazed in a new tab, even if a very short period of time passed before an older tab was closed.

With this change `msal-broswer` will store Microsoft Graph access tokens in a location within a web browser that can be accessed between different sessions (e.g. if you close browser and reopen it again). Tokens don't live forever, but if you reopen Mazed when they are still alive then they will be seamlessly reused.

#148 