### PR TITLE
Bugfix: auto connect a quote to a bookmark

### DIFF
--- a/archaeologist/src/content/quote/QuoteHighlight.tsx
+++ b/archaeologist/src/content/quote/QuoteHighlight.tsx
@@ -139,11 +139,9 @@ export const QuoteHighlight = ({
   const [highlights, setHighlights] = useState<ElementHighlight[]>([])
   useEffect(() => {
     const target = document.querySelector(path.join(' > '))
-    if (target != null) {
-      setHighlights([])
-    }
     setHighlights(discoverHighlightsInElement(target, highlightPlaintext))
-  }, [nid, path, highlightPlaintext])
+    return () => setHighlights([])
+  }, [path, highlightPlaintext])
   return (
     <>
       {highlights.map(({ target, slice }, index) => {


### PR DESCRIPTION
Autoconnection a new quote to a preexisting bookmark and a new bookmark to preexisting quotes of the same page. It was broken due to incorrect dependencies among state fragments for `App` element in content script and `useEffect` to register message listener. Basically first version of the listener function was added and never updated.

What was done to fix it:
- Listener is wrapped up in `React.useCallback` to avoid regenerating it on every render. Regeneration happens only if either a new quote or a bookmark is created.
- Re-register listener callback if it's changed.
- Also fixed dependency in `QuoteHighlight.txt`, not important, but still was not correct.

Clean ups for #227 

Proof that it works now:

https://user-images.githubusercontent.com/2223470/179218686-89b564f6-18fc-47e1-84da-d90d7c634add.mov

