### PR TITLE
Don't show [bookmark] button in PopUp window for unmemorable pages

### DIFF
--- a/archaeologist/src/background.ts
+++ b/archaeologist/src/background.ts
@@ -176,20 +176,22 @@ async function handleMessageFromPopup(
         tabId
       )
       return { type: 'PAGE_SAVED', bookmark: node?.toJson(), unmemorable }
-    case 'REQUEST_PAGE_IN_ACTIVE_TAB_STATUS':
-      const data = await requestPageSavedStatus(activeTab)
+    case 'REQUEST_PAGE_IN_ACTIVE_TAB_STATUS': {
+      const { quotes, bookmark, unmemorable } = await requestPageSavedStatus(
+        activeTab
+      )
       await badge.resetText(
         activeTab?.id,
-        calculateBadgeCounter(data.quotes, data.bookmark)
+        calculateBadgeCounter(quotes, bookmark)
       )
-      const quotesJson = data.quotes.map((node) => node.toJson())
-      const bookmarkJson = data.bookmark?.toJson()
       return {
         type: 'UPDATE_POPUP_CARDS',
         mode: 'reset',
-        quotes: quotesJson,
-        bookmark: bookmarkJson,
+        quotes: quotes.map((node) => node.toJson()),
+        bookmark: bookmark?.toJson(),
+        unmemorable,
       }
+    }
     case 'REQUEST_AUTH_STATUS':
       const status = await getAuthStatus()
       badge.setActive(status)


### PR DESCRIPTION
unmemorable pages could not be bookmarked anyway, it's just too confusing to show button there.

Resolves: #255 