### PR TITLE
Tidy up fonts - use same font for archaeologist and truthsayer

### DIFF
--- a/archaeologist/public/popup.html
+++ b/archaeologist/public/popup.html
@@ -11,6 +11,8 @@
     href="https://fonts.googleapis.com/icon?family=Material+Icons"
     rel="stylesheet"
   />
+  <link href='https://fonts.googleapis.com/css?family=Comfortaa' rel='stylesheet'>
+  <link href='https://fonts.googleapis.com/css?family=Roboto' rel='stylesheet'>
 </head>
 
 <body>

--- a/archaeologist/src/popup/PopUpApp.tsx
+++ b/archaeologist/src/popup/PopUpApp.tsx
@@ -15,6 +15,9 @@ import { MdiLaunch } from 'elementary'
 const AppContainer = styled.div`
   width: 280px;
   height: 280px;
+  font-family: 'Roboto', arial, sans-serif;
+  font-style: normal;
+  font-weight: 400;
 `
 
 export const PopUpApp = () => {

--- a/truthsayer/public/index.html
+++ b/truthsayer/public/index.html
@@ -31,6 +31,8 @@
       See https://fonts.google.com/specimen/Comfortaa for more info
     -->
     <link href='https://fonts.googleapis.com/css?family=Comfortaa' rel='stylesheet'>
+    <!-- Font to style all other texts -->
+    <link href='https://fonts.googleapis.com/css?family=Roboto' rel='stylesheet'>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/truthsayer/src/App.js
+++ b/truthsayer/src/App.js
@@ -64,6 +64,10 @@ function AppRouter() {
           margin: 0;
           padding: 0;
 
+          font-family: 'Roboto', arial, sans-serif;
+          font-style: normal;
+          font-weight: 400;
+
           @media (min-width: 480px) {
             .app_content {
               padding-left: 4px;

--- a/truthsayer/src/card/Triptych.tsx
+++ b/truthsayer/src/card/Triptych.tsx
@@ -354,7 +354,7 @@ export class Triptych extends React.Component<TriptychProps, TriptychState> {
     return (
       <Row
         css={css`
-          margin: 1px 0 0 0;
+          margin: 1px 10px 0 10px;
           padding: 0;
           width: 100%;
           display: flex;
@@ -397,9 +397,9 @@ export class Triptych extends React.Component<TriptychProps, TriptychState> {
         <Col
           css={css`
             ${colBaseCss};
-            flex: 0 1 510px;
+            flex: 0 1 420px;
             margin: 0 8px 0 8px;
-            width: 480px;
+            width: 420px;
           `}
         >
           <WideCard>

--- a/truthsayer/src/navbar/GlobalNavBar.module.css
+++ b/truthsayer/src/navbar/GlobalNavBar.module.css
@@ -3,12 +3,6 @@
   width: 100%;
 }
 
-.brand {
-  display: flex;
-  justify-content: space-between;
-  margin-right: 0.5rem;
-}
-
 .logo_image {
   width: 1.6rem;
   height: 1.6rem;

--- a/truthsayer/src/navbar/GlobalNavBar.tsx
+++ b/truthsayer/src/navbar/GlobalNavBar.tsx
@@ -92,8 +92,14 @@ const CustomNavbar = styled(Navbar)`
   padding-left: 0.8rem;
   padding-right: 0.8rem;
   justify-content: space-between;
-  font-family: 'Comfortaa';
   ${kCardBorder};
+`
+
+const NavbarBrand = styled(Navbar.Brand)`
+  display: flex;
+  justify-content: space-between;
+  margin-right: 0.5rem;
+  font-family: 'Comfortaa';
 `
 
 export function GlobalNavBar() {
@@ -105,14 +111,14 @@ export function GlobalNavBar() {
   return (
     <>
       <CustomNavbar fixed="top" className={styles.navbar}>
-        <Navbar.Brand as={Link} to="/" className={styles.brand}>
+        <NavbarBrand as={Link} to="/">
           <img
             src={getLogoImage()}
             alt={'Mazed logo'}
             className={styles.logo_image}
           />
           <div className="d-none d-sm-none d-md-block">Mazed</div>
-        </Navbar.Brand>
+        </NavbarBrand>
         <PrivateNavButtons />
       </CustomNavbar>
       <div className={styles.navbar_filler} />


### PR DESCRIPTION
To make it look better in demos.

- Added new font for all texts in Mazed - `Roboto` (Google Keep uses it)
- Added a bit of a margin on the left and right for `Triptych` to make it look tidy on narrow screens.

<img width="923" alt="Screenshot 2022-08-18 at 11 39 05" src="https://user-images.githubusercontent.com/2223470/185376394-35b6c220-eeef-471e-8c25-8c1251d91410.png">
