### PR TITLE
Complience with out inital cookie policy

### DIFF
--- a/smuggler-api/src/auth/cookie.ts
+++ b/smuggler-api/src/auth/cookie.ts
@@ -62,7 +62,12 @@ export const authCookie = {
     },
     set: async (value: SmugglerTokenLastUpdateCookies): Promise<void> => {
       const cookies = new Cookies()
-      return cookies.set(COOKIES_LAST_UPDATE_KEY, value)
+      return cookies.set(COOKIES_LAST_UPDATE_KEY, value, {
+        // Max age is 1 year
+        // If changed, don't forget to update Cookie Policy document
+        // legal/cookie-policy.md
+        maxAge: 1 + 365 * 24 * 60 * 60,
+      })
     },
   },
 }

--- a/truthsayer/src/landing-page/LandingPage.tsx
+++ b/truthsayer/src/landing-page/LandingPage.tsx
@@ -3,6 +3,13 @@ import { BuilderComponent, builder } from '@builder.io/react'
 
 builder.init('0472fab3b2de47449c0ac0d0bd8d15b0')
 
+// Disable builder cookies for GDPR Compliance
+// https://forum.builder.io/t/gdpr-compliance/292/6
+//
+// If changed, don't forget to update Cookie Policy document
+// legal/cookie-policy.md
+builder.canTrack = false
+
 export const LandingPage = () => {
   const [builderContentJson, setBuilderContentJson] = React.useState<any>(null)
   React.useEffect(() => {


### PR DESCRIPTION
Compliance with our initial cookie policy : https://docs.google.com/document/d/1O_Y8NgRlcg9kfnXUYtYLEMw1JW9ydHQSrlCr_tCHSTs

There are 2 things:
- Disable tracking by builder.io (and setting up session cookies)
- Add expiration date for `x-magic-smuggler-token-last-update`