### PR TITLE
Break main landing page title only in the middle

### DIFF
--- a/truthsayer/src/landing-page/LandingPage.tsx
+++ b/truthsayer/src/landing-page/LandingPage.tsx
@@ -356,7 +356,8 @@ export function LandingPage() {
           </Topbar>
           <FirstSlideBody>
             <Header>
-              Reference anything you've read. <wbr />
+              Reference&nbsp;anything you've&nbsp;read.
+              <wbr />
               <b>Without&nbsp;looking&nbsp;for&nbsp;it.</b>
             </Header>
             <Description>


### PR DESCRIPTION
Used non-breakable spaces for the rest of the line, except one space in the middle