### PR TITLE
open tabs bootstrap: handle discarded tabs

### DIFF
--- a/archaeologist/src/background/external-import/openTabs.ts
+++ b/archaeologist/src/background/external-import/openTabs.ts
@@ -126,15 +126,4 @@ export namespace OpenTabs {
   function isValidTab(tab: browser.Tabs.Tab): tab is ValidTab {
     return tab.id != null && tab.url != null
   }
-
-  function sleep(ms: number) {
-    return new Promise((resolve) => setTimeout(resolve, ms))
-  }
-  function timeout(ms: number, timedOutAction: string) {
-    return sleep(ms).then(() => {
-      throw new Error(
-        `Following action timed out after ${ms / 1000} sec: '${timedOutAction}'`
-      )
-    })
-  }
 }


### PR DESCRIPTION
Currently the logic hangs indefinitely if some of the open tabs are in a discarded state (Chrome's [Memory Saver](https://blog.google/products/chrome/new-chrome-features-to-save-battery-and-make-browsing-smoother/) and Edge's [sleeping tabs](https://blogs.windows.com/msedgedev/2020/12/09/sleeping-tabs-beta-performance/) are examples of when browsers do this automatically).

It's not possible to undiscard them it seems, but possible to refresh.

Fixes #375 