### PR TITLE
add missing 'this' to Knocker.abort()

### DIFF
--- a/smuggler-api/src/auth/knocker.ts
+++ b/smuggler-api/src/auth/knocker.ts
@@ -100,7 +100,7 @@ export class Knocker {
    * @see stop() for a side effect-free version.
    */
   abort = async () => {
-    stop()
+    this.stop()
     if (this.#abortCallback) {
       this.#abortCallback()
     }


### PR DESCRIPTION
To fix a regression introduced in #490