### PR TITLE
Re-run similarity search on each page URL update or switch between typing and reading

### DIFF
--- a/archaeologist/src/content/augmentation/SuggestedRelatives.tsx
+++ b/archaeologist/src/content/augmentation/SuggestedRelatives.tsx
@@ -46,7 +46,6 @@ export function SuggestedRelatives({
   stableUrl?: string
   excludeNids?: Nid[]
 }) {
-  log.debug('SuggestedRelatives', stableUrl)
   const [suggestedNodes, setSuggestedNodes] = React.useState<TNode[]>([])
   const [suggestionsSearchIsActive, setSuggestionsSearchIsActive] =
     React.useState<boolean>(true)
@@ -106,7 +105,6 @@ export function SuggestedRelatives({
     (keyboardEvent: KeyboardEvent) => {
       const newInput = updateUserInputFromKeyboardEvent(keyboardEvent)
       const { phrase } = newInput
-      log.debug('consumeKeyboardEvent', phrase, userInput)
       if (phrase != null && phrase.length > 3 && userInput.phrase !== phrase) {
         requestSuggestedAssociations(phrase)
         setUserInput(newInput)


### PR DESCRIPTION
Re-run similarity search on each page URL update or switch between typing and reading.

- Enforce similarity search when page URL is changed.
- Re-run similarity search for the page content, when user stopped typing a comment and switched back to reading.

Resolves: #501 

~⚠️ Depends on #500~

Demo:

https://user-images.githubusercontent.com/2223470/224546323-da87387a-0278-4ab4-bfd2-ea29183cb976.mov

