### PR TITLE
Open Chrome Store Page for Archaeologist in a new tab

### DIFF
--- a/truthsayer/src/apps-list/AppsList.tsx
+++ b/truthsayer/src/apps-list/AppsList.tsx
@@ -49,7 +49,15 @@ function describe(state: ArchaeologistState) {
       return <Button disabled>Installed</Button>
     }
     case 'not-installed': {
-      return <Button href={kGoogleChromeStoreLink}>Install</Button>
+      return (
+        <Button
+          href={kGoogleChromeStoreLink}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Install
+        </Button>
+      )
     }
   }
 }


### PR DESCRIPTION
Open Chrome Store Page for Archaeologist in a new tab, to keep onboarding tab active. This way onboarding tab will be able to bring user back into onboarding flow when Archaeologist is installed.

#509