### PR TITLE
Sync font-size of the email form and comment above on the landing page

### DIFF
--- a/truthsayer/src/landing-page/LandingPage.tsx
+++ b/truthsayer/src/landing-page/LandingPage.tsx
@@ -175,7 +175,7 @@ const SignUpFormBox = styled.form`
   border-radius: 10px;
   width: 100%;
 
-  font-size: ${FontSize[2]};
+  font-size: ${FontSize[3]};
   @media (max-width: 600px) {
     font-size: ${FontSize[5]};
   }


### PR DESCRIPTION
Before
<img width="1800" alt="Screenshot 2023-04-03 at 15 36 20" src="https://user-images.githubusercontent.com/2223470/229542371-65ad3424-5ea1-4f6f-8d83-a0b9b639518e.png">

After
<img width="1800" alt="Screenshot 2023-04-03 at 15 36 28" src="https://user-images.githubusercontent.com/2223470/229542388-57c2cb25-298b-4689-9010-d5db9fba648e.png">

