### PR TITLE
Keep aspect ratio for Tango iframe

### DIFF
--- a/truthsayer/src/account/onboard/Onboarding.tsx
+++ b/truthsayer/src/account/onboard/Onboarding.tsx
@@ -233,10 +233,10 @@ const StepYouAreReadyToGo = ({
 const StepTangoShowAroundBox = styled(StepBox)`
   height: calc(100vh - 40px); /* leave some space for bottom bar */
   width: 100%;
-  @media (min-width: 1140px) {
-    width: 1140px;
+  @media (min-width: 1280px) {
+    width: 1280px;
     margin: 0 auto 0 auto;
-    padding-top: calc(100vh - 1140px);
+    padding-top: calc(100vh - 1280px);
   }
 `
 const StepTangoIframBox = styled.div`


### PR DESCRIPTION
The original aspect ratio for the Tango demo is apparently 3x2, this is why we use `padding-bottom: 66.66%`.

Here how it looks being embedded:


https://user-images.githubusercontent.com/2223470/230780081-306dd3ff-0be7-42f8-850d-31620ee01f97.mov

<img width="936" alt="Screenshot 2023-04-09 at 16 03 29" src="https://user-images.githubusercontent.com/2223470/230780737-6c316d2f-553d-435c-a5e6-7e1ef7dab661.png">
