### PR TITLE
Reduce size of the Tago demo even further - down to 720px

### DIFF
--- a/truthsayer/src/account/onboard/Onboarding.tsx
+++ b/truthsayer/src/account/onboard/Onboarding.tsx
@@ -233,10 +233,10 @@ const StepYouAreReadyToGo = ({
 const StepTangoShowAroundBox = styled(StepBox)`
   height: calc(100vh - 40px); /* leave some space for bottom bar */
   width: 100%;
-  @media (min-width: 1280px) {
-    width: 1280px;
+  @media (min-width: 720px) {
+    width: 720px;
     margin: 0 auto 0 auto;
-    padding-top: calc(100vh - 1280px);
+    padding-top: calc(100vh - 1200px);
   }
 `
 const StepTangoIframBox = styled.div`
@@ -244,10 +244,10 @@ const StepTangoIframBox = styled.div`
   width: 100%;
   height: 0;
   /**
-  * 66.66 = 2/3 because of the aspect ratio of 3:2, see
+  * 0.75 = 3/4 because of the aspect ratio of 4:3, see
   * https://stackoverflow.com/questions/25302836/responsive-video-iframes-keeping-aspect-ratio-with-only-css
   */
-  padding-bottom: 66.66%;
+  padding-bottom: 75%;
 `
 const StepTangoIframe = styled.iframe`
   position: absolute;


### PR DESCRIPTION
Here how it looks like on my screens with this:


<img width="3200" alt="Screenshot 2023-04-10 at 10 26 53" src="https://user-images.githubusercontent.com/2223470/230874610-6c477b3f-3ee4-4d0f-ab63-d26832ca815f.png">

<img width="949" alt="Screenshot 2023-04-10 at 10 27 05" src="https://user-images.githubusercontent.com/2223470/230874597-f8b9b01a-6bf3-4725-b023-e7a06f3d3e7a.png">
