### PR TITLE
Adjust X position of the floater on a change of 'revealed' status

### DIFF
--- a/archaeologist/src/content/augmentation/SuggestionsFloater.tsx
+++ b/archaeologist/src/content/augmentation/SuggestionsFloater.tsx
@@ -218,8 +218,16 @@ export const SuggestionsFloater = ({
             `Full error: "${errorise(e).message}"`
         )
       }
-
       setRevealed(revealed)
+      // Reset floater position to adjust horisontal position (X), it has only
+      // 2 values for revealed/hidden floater. Y position must remain the same.
+      setControlledPosition((prev) => {
+        const defaultPosition = getStartDragPosition(revealed)
+        return {
+          x: defaultPosition.x,
+          y: frameYPosition(prev?.y ?? defaultPosition.y),
+        }
+      })
       analytics?.capture('Click SuggestionsFloater visibility toggle', {
         'Event type': 'change',
         isRevealed: revealed,


### PR DESCRIPTION
And now we know why we had `setControlledPosition` inside `saveRevealed` 😅 , related to #580 

# Before (now)

https://user-images.githubusercontent.com/2223470/231182894-d557f14a-d6df-4ae8-8e16-a9ed1431f792.mov

# After

https://user-images.githubusercontent.com/2223470/231182572-03a09bb3-bfec-4799-bfcf-70379f37f815.mov


