### PR TITLE
log (on dev) when PostHog rejects events

### DIFF
--- a/armoury/package.json
+++ b/armoury/package.json
@@ -24,7 +24,7 @@
     "js-base64": "^3.6",
     "lodash": "^4.17.21",
     "moment": "^2.29.4",
-    "posthog-js": "^1.34.0",
+    "posthog-js": "^1.53.4",
     "prettier": "^2.2",
     "query-string": "^7.0.0",
     "ts-jest": "^26.4.2",

--- a/armoury/src/productanalytics.ts
+++ b/armoury/src/productanalytics.ts
@@ -44,6 +44,14 @@ function makeAnalytics(
     const posthogToken = 'phc_p8GUvTa63ZKNpa05iuGI7qUvXYyyz3JG3UWe88KT7yj'
     const posthogApiHost = 'https://eu.posthog.com'
     const finalConfig: Partial<PostHogConfig> = {
+      on_xhr_error: (posthogReq: XMLHttpRequest) => {
+        if (nodeEnv !== 'development') {
+          return
+        }
+        log.warning(
+          `Failed to send analytics event: ${posthogReq.status} ${posthogReq.responseText}`
+        )
+      },
       ...config,
       api_host: posthogApiHost,
       // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#restrict_access_to_cookies

--- a/yarn.lock
+++ b/yarn.lock
@@ -3758,13 +3758,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:^7.2.0":
-  version: 7.18.0
-  resolution: "@sentry/types@npm:7.18.0"
-  checksum: e05581cd6eb1b79208fe85ba7043f9b2606b49eab64d7207ad2490061aebd66bc1a29a6234001c74b3098221564fa68c5d1b1be2566cf6328c576ada7240b190
-  languageName: node
-  linkType: hard
-
 "@sinclair/typebox@npm:^0.23.3":
   version: 0.23.5
   resolution: "@sinclair/typebox@npm:0.23.5"
@@ -5806,7 +5799,7 @@ __metadata:
     js-base64: ^3.6
     lodash: ^4.17.21
     moment: ^2.29.4
-    posthog-js: ^1.34.0
+    posthog-js: ^1.53.4
     prettier: ^2.2
     query-string: ^7.0.0
     ts-jest: ^26.4.2
@@ -17304,14 +17297,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"posthog-js@npm:^1.34.0":
-  version: 1.34.0
-  resolution: "posthog-js@npm:1.34.0"
+"posthog-js@npm:^1.53.4":
+  version: 1.53.4
+  resolution: "posthog-js@npm:1.53.4"
   dependencies:
-    "@sentry/types": ^7.2.0
     fflate: ^0.4.1
     rrweb-snapshot: ^1.1.14
-  checksum: a02f2772a29c2344abdd98d6495ce8b58e3589a50f746f4e6a8d2a5718f8e8d4ca6939888e36e619f8a28c85d7de1ac0eae6d0c2451b8537796000cd55768a8e
+  checksum: c101770ef143d58dc654758885c89e6ad2a106ffe629b69e2d1096a046aeccb01cedc4c637c2f0c1e8e297e6bd27f4fd2fced79e30360173773ec8cd3b30e62f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Currently if PostHog doesn't like something in the events we publish it is very difficult to figure out what's wrong. With this change at least on dev it'll log messages like

> `[Mazed/warning] Failed to send analytics event to PostHog: 400 {"type": "validation_error", "code": "invalid_payload", "detail": "Invalid payload: All events must have the event field \"distinct_id\"!", "attr": null}`