### PR TITLE
Replace Onboarding demo from Tango with Arcade one

### DIFF
--- a/truthsayer/src/account/onboard/Onboarding.tsx
+++ b/truthsayer/src/account/onboard/Onboarding.tsx
@@ -232,7 +232,7 @@ const StepYouAreReadyToGo = ({
 
 const StepTangoShowAroundBox = styled(StepBox)`
   margin: 0 auto 0 auto;
-  padding-top: calc(100vh - 1000px);
+  padding-top: calc(100vh - 1200px);
   height: calc(100vh - 40px); /* leave some space for bottom bar */
   width: 100%;
   @media (min-width: 740px) {


### PR DESCRIPTION
Demo:

<img width="2121" alt="Screenshot 2023-04-23 at 16 04 49" src="https://user-images.githubusercontent.com/2223470/233847566-5b09edc9-d00d-446c-bc7c-4d5e0f377183.png">
