### PR TITLE
Special text extractor for google documents

### DIFF
--- a/archaeologist/src/content/extractor/webPageContent.ts
+++ b/archaeologist/src/content/extractor/webPageContent.ts
@@ -605,34 +605,6 @@ export function _extractPlainTextFromContentHtml(
 }
 
 /**
- * Bunch of hacks to make plaintext representation looks readable
- */
-export function _extractPlainTextFromContentHtml(
-  html: string,
-  textContent: string
-): string {
-  // We don't trust MozillaReadability with plaintext extraction - it drops
-  // spaces a lot in random places, text without spaces between words
-  // affects similarity search quality. Instead we deal with dropping HTML
-  // tags ourselves from HTML version of content from MozillaReadability.
-  let clean = DOMPurify.sanitize(html, {
-    USE_PROFILES: { html: true },
-  })
-  const doc = new DOMParser().parseFromString(
-    clean
-      .replace(/<\/(h\d|tr)>/gi, '.')
-      .replace(/<[^>]*>/g, ' ')
-      .replace(/(\.\s+){2,}/g, '. '), // Because we insert shedload of dots above, let's remove excesive ones
-    'text/html'
-  )
-  return unicodeText.trimWhitespace(
-    sortOutSpacesAroundPunctuation(
-      doc.documentElement?.textContent ?? textContent
-    )
-  )
-}
-
-/**
  * Try to fetch images for given urls. First successfully retrieved image is
  * returned, so sort urls by priority beforehands placing best options for a
  * preview image at the front of the `thumbnailUrls` array.


### PR DESCRIPTION
Dirty hack → scan doc to discover all `<script>` tags, some of them contain the text we need, just identifying those and getting text from them. It's very fragile, I know. But as for now, all we need is to prove this can work for most often used documents. Google Doc is one of those types. Later on we can rebuilt it using proper Google Drive API with authorisation.

Resolves: #682 