### PR TITLE
Onboarding: Single call to action on each slide

### DIFF
--- a/truthsayer/src/external-import/BrowserHistoryImporter.tsx
+++ b/truthsayer/src/external-import/BrowserHistoryImporter.tsx
@@ -213,9 +213,9 @@ function BrowserHistoryImportControl({
 function BrowserHistoryImportControlForOnboarding({
   progress,
   disabled,
-  onClick,
+  onStart,
 }: {
-  onClick?: () => void
+  onStart?: () => void
 } & UploadBrowserHistoryProps) {
   const [state, setState] = React.useState<BrowserHistoryImportControlState>(
     progress.processed !== progress.total
@@ -235,6 +235,7 @@ function BrowserHistoryImportControlForOnboarding({
         type: 'UPLOAD_BROWSER_HISTORY',
         ...mode,
       })
+      onStart?.()
     } catch (err) {
       setState({
         step: 'standby',
@@ -260,7 +261,6 @@ function BrowserHistoryImportControlForOnboarding({
         </Comment>
         <OnboardingButton
           onClick={() => {
-            onClick?.()
             startUpload({
               mode: 'untracked',
               unixtime: {
@@ -326,10 +326,10 @@ export function BrowserHistoryImporterForOnboarding({
   archaeologistState,
   progress,
   disabled,
-  onClick,
+  onStart,
 }: {
   archaeologistState: ArchaeologistState
-  onClick?: () => void
+  onStart?: () => void
 } & UploadBrowserHistoryProps) {
   switch (archaeologistState.state) {
     case 'not-installed': {
@@ -350,7 +350,7 @@ export function BrowserHistoryImporterForOnboarding({
     <BrowserHistoryImportControlForOnboarding
       progress={progress}
       disabled={disabled}
-      onClick={onClick}
+      onStart={onStart}
     />
   )
 }

--- a/truthsayer/src/external-import/ExternalImport.tsx
+++ b/truthsayer/src/external-import/ExternalImport.tsx
@@ -129,12 +129,12 @@ export function ExternalImportForOnboarding({
   className,
   archaeologistState,
   progress,
-  onClick,
+  onStart,
 }: {
   className?: string
   archaeologistState: ArchaeologistState
   progress: ExternalImportProgress
-  onClick?: () => void
+  onStart?: () => void
 }) {
   const isFinished = (progress: BackgroundActionProgress) =>
     progress.total !== 0 && progress.total === progress.processed
@@ -147,7 +147,7 @@ export function ExternalImportForOnboarding({
             archaeologistState={archaeologistState}
             progress={progress.historyImportProgress}
             disabled={isFinished(progress.historyImportProgress)}
-            onClick={onClick}
+            onStart={onStart}
           />
         </Item>
       </ItemsBox>

--- a/truthsayer/src/lib/route.ts
+++ b/truthsayer/src/lib/route.ts
@@ -72,11 +72,15 @@ export type NoticeUrlParams = { page: string }
 export type History = RouteComponentProps['history']
 export type Location = RouteComponentProps['location']
 
-function gotoSearch({ history, query }: { history: History; query: string }) {
-  history.push({
-    pathname: kSearchPath,
-    search: stringify({ q: query }),
-  })
+function gotoSearch({ history, query }: { history?: History; query: string }) {
+  if (history) {
+    history.push({
+      pathname: kSearchPath,
+      search: stringify({ q: query }),
+    })
+  } else {
+    window.location.assign(`${kSearchPath}?${stringify({ q: query })}`)
+  }
 }
 
 function gotoOnboarding({


### PR DESCRIPTION
- Removed [Next] button from bootstrap slide, just go to the next slide automatically when user starts bootstrap process.
- Replaced [Done] button on the demo slide (last one), converted it to a small [Close] button at the right top corner of the demo.
- Added full reloading of the web app after onboarding, because sometimes cards after bootstrap don't show up - only after full reload (no time to test that now - reloading fixes the issue).

<img width="1048" alt="Screenshot 2023-05-03 at 08 52 55" src="https://user-images.githubusercontent.com/2223470/235860003-280e0d6c-ece0-46e0-93be-e28d91b7568e.png">

<img width="846" alt="Screenshot 2023-05-03 at 08 53 05" src="https://user-images.githubusercontent.com/2223470/235859994-63eb8a2b-e92f-44f3-a36d-abd18786dc44.png">

Resolves: #603 