### PR TITLE
rm unused 'MazedMiniFloater:Click' analytics event

### DIFF
--- a/archaeologist/src/content/augmentation/MazedMiniFloater.tsx
+++ b/archaeologist/src/content/augmentation/MazedMiniFloater.tsx
@@ -4,7 +4,6 @@ import React from 'react'
 import styled from '@emotion/styled'
 
 import LogoImage from '../../../public/logo-strip.svg'
-import { ContentContext } from '../context'
 import { StyleButtonCreate } from 'elementary'
 
 const Box = styled.div`


### PR DESCRIPTION
It has been replaced in all dashboards with a more capable `Click SuggestionsFloater visibility toggle` event which captures both open & minimise events.