### PR TITLE
Show floater opened by default only if there are suggestions

### DIFF
--- a/elementary/src/media/WebBookmark.tsx
+++ b/elementary/src/media/WebBookmark.tsx
@@ -9,9 +9,9 @@ import {
   getPrevBlockKey,
   nodeBlockKeyToString,
 } from 'smuggler-api'
+
 import type { Optional } from 'armoury'
 import { getNodeBlock } from '../editor/types'
-
 import {
   padNonEmptyStringWithSpaceHead,
   productanalytics,


### PR DESCRIPTION
Show floater opened for search engines e.g. Google Search by default only if there are suggestions.